### PR TITLE
Fix broken links and add description for "Sources" header on the Tags page

### DIFF
--- a/src/content/docs/Artist entry creation.mdx
+++ b/src/content/docs/Artist entry creation.mdx
@@ -16,9 +16,9 @@ If you're unsure if the artist should be added in the first place, please read t
 
 Minimum (technical) entry creation requirements:
 
-- [Name](/docs/artists/artist-entry-editing#tab-Basic-info)
-- [Description](/docs/artists/artist-entry-editing#Artist-description) OR [External link](/docs/artists/artist-entry-editing#External-links)
+- [Name](/docs/artists/artist-entry-editing#tab-basic-info)
+- [Description](/docs/artists/artist-entry-editing#artist-description) OR [External link](/docs/artists/artist-entry-editing#external-links)
 
-These are the **same** as [finished artist entry requirements](/docs/artists/artist-entry-editing#Finished-artist-entry-requirements).
+These are the **same** as [finished artist entry requirements](/docs/artists/artist-entry-editing#finished-artist-entry-requirements).
 
 After submitting the artist, you can add more detailed information to the entry on the [artist edit page](/docs/artists/artist-entry-editing).

--- a/src/content/docs/Song entry creation.mdx
+++ b/src/content/docs/Song entry creation.mdx
@@ -19,7 +19,7 @@ Minimum (technical) entry creation requirements:
 - [Name](/docs/songs/song-entry-editing#names)
 - 1 [Artist](/docs/songs/song-entry-editing#tab-artists)
 
-These are **different** from the [finished song entry requirements](/docs/songs/song-entry-editing#Finished-song-entry-requirements).
+These are **different** from the [finished song entry requirements](/docs/songs/song-entry-editing#finished-song-entry-requirements).
 
 If the artist entry doesn't exist, you will need to use the ["Add an artist" page](https://vocadb.net/Artist/Create) to create an entry. 
 

--- a/src/content/docs/Tags.mdx
+++ b/src/content/docs/Tags.mdx
@@ -137,7 +137,7 @@ Tags are one way of representing song series.
 
 ### Sources
 
--
+Information relating to a song's origin, for example, that it was produced in [FL Studio](https://vocadb.net/T/3257/fl-studio) or that it was an artist's [first work](https://vocadb.net/T/158)
 
 ### Subjective
 

--- a/src/content/docs/User groups.mdx
+++ b/src/content/docs/User groups.mdx
@@ -14,7 +14,7 @@ users are able to edit most entries, rate songs and albums, post comments and mo
 
 ## Trusted user
 
-Once we have seen that a user knows and respects the basic rules on the site and that they're likely going to stay longer than a few days, we eventually promote them to trusted. You can read [this wiki page](Trusted users) for more about the trusted user status.
+Once we have seen that a user knows and respects the basic rules on the site and that they're likely going to stay longer than a few days, we eventually promote them to trusted. You can read [this wiki page](/docs/documentation/trusted-users) for more about the trusted user status.
 
 In addition to regular user features, trusted users have access to the following:
 * [Deleting any entry ](/docs/other-guidelines/content-removal-guidelines) (not just the ones they created)
@@ -36,7 +36,7 @@ In addition to **trusted user features**, moderators have access to the followin
 * Disabling misbehaving user accounts
 * Promoting users from regular to trusted
 
-Also see [management guidelines](/docs/guidelines/management-guidelines).
+Also see [management guidelines](/docs/other-guidelines/management-guidelines).
 
 ## Administrator
 
@@ -54,7 +54,7 @@ Occasionally we have to reduce an account from regular to limited. Limited users
 
 Verified artists are able to approve their assigned artist entry, restricting editing for that entry. Additionally, they are able to use VocaDB to host their songs, by uploading mp3 files that can be played on site.
 
-* [Artist verification](/docs/artist/artist-verification)
+* [Artist verification](/docs/artists/artist-verification)
 
 ### Email verification
 

--- a/src/content/docs/VocaDB editing FAQ.mdx
+++ b/src/content/docs/VocaDB editing FAQ.mdx
@@ -27,7 +27,7 @@ Generally no, with some exceptions:
 
 Rationale: if the original song is on VocaDB, repeating the original artists for derivatives is redundant, and redundant information should be avoided.
 
-Documented on [Song entry editing](docs/songs/song-entry-editing#tab-artists).
+Documented on [Song entry editing](/docs/songs/song-entry-editing#tab-artists).
 
 ### If a Vocaloid song was released simultaneously with a human vocals version, which one is the original?
 
@@ -35,7 +35,7 @@ On VocaDB we give preference to the Vocaloid version, unless the artist clearly 
 
 Related tags: [simultaneous upload](https://vocadb.net/T/4946/simultaneous-upload), [self-cover](https://vocadb.net/T/391)
 
-Documented on [Song entry editing](docs/songs/song-entry-editing#cover).
+Documented on [Song entry editing](/docs/songs/song-entry-editing#cover).
 
 ### I think that the song is using an append (or other version than indicated), but can't confirm. Which voicebank should I use?
 
@@ -64,7 +64,7 @@ The publish date on VocaDB must be the earliest date one of these happened. Priv
 
 If the song is deleted and then reuploaded, the publish date does not change. It's still the date when the song was first made public.
 
-Documented on [Song entry editing](docs/songs/song-entry-editing#publish-date).
+Documented on [Song entry editing](/docs/songs/song-entry-editing#publish-date).
 
 ----
 


### PR DESCRIPTION
## Fixes:
### <p align="center">Several links that previously led to a "Not Found" or did not jump to headers have been fixed:<p>

- User Groups: Trusted Users page is now correctly linked, fix broken links
-  Artist Entry Creation: Fix header links so that they jump to the correct header as intended
- Song Entry Creation: Fix header links so that they jump to the correct header as intended
- Editing FAQ: Fix broken links

## Additions:
### <p align="center">Definitions <p>

- Tags; The "Source" definition on this page was previously blank. A definition has been added.