### PR TITLE
Add more info to trusted users and entry reports pages

### DIFF
--- a/src/content/docs/Entry reports.mdx
+++ b/src/content/docs/Entry reports.mdx
@@ -9,6 +9,8 @@ Entry reports are a way of communicating **edit-related mistakes**. Two main rea
 * Making a note that there's an issue that should be fixed.
 * Giving the previous editor a chance to correct their mistake and hopefully **learn from it** .
 
+To allow the editor to learn from their mistake, Trusted Users should typically wait **at least 24 hours** before closing entry reports, besides those that the original editor cannot fix themselves or are on older edits.
+
 The list of [open entry reports](https://vocadb.net/Admin/ViewEntryReports) is visible to all [trusted users](/docs/documentation/user-groups) and above.
 
     * Trusted users should ignore moderation-related reports such as [artist verification](/docs/artists/artist-verification) and [content removal](/docs/other-guidelines/content-removal-guidelines) requests.
@@ -77,7 +79,7 @@ This list shows suggestions that should be followed to prevent **unclear situati
 
 ## DON'T spam entry reports of the same type
 
-If the same report applies to multiple entries, list those entries under one report or in a comment under one of the relevant entries, or message a moderator.
+If the same report applies to multiple entries, list those entries under one report, in a comment under one of the relevant entries, or message a moderator.
 
 ## DO prefer reporting a specific version
 
@@ -91,6 +93,10 @@ If the mistake was made months, even years ago, there's not much point in report
 
 The expectation is that the previous editor who made the mistake would be the one to correct it, but assuming they don't, the best thing you as the reporter can do is to correct the mistake yourself when you get the chance. Some people don't check the site very often, or maybe they didn't even get the notification.
 
-## As a trusted user / moderator, DON'T let reports lie there for weeks
+## DON'T let reports lie there for weeks (Trusted Users/Moderators)
 
 When a report is over a week old, it should be taken care of somehow. If you can, please fix the problem.
+
+## DO provide explanations in your reports
+
+Especially for newer editors, it might not be obvious what to fix when their entry is reported for something like "title needs to be cleaned", "incorrect X", etc. It is useful to be **specific** as to what is wrong in the entry and provide relevant wiki pages/quotes.

--- a/src/content/docs/Trusted users.mdx
+++ b/src/content/docs/Trusted users.mdx
@@ -5,24 +5,32 @@ parent: Documentation
 tags: ["documentation", "editing", "guidelines", "moderation", "user", "vocadb"]
 ---
 
-Trusted user is someone who has been given access to full editing functionality on VocaDB, such as deleting or merging entries.
+A Trusted user is someone who has been given access to full editing functionality on VocaDB.
+
+Trusted users have access to the following additional permissions:
+* [Deleting any entry](/docs/other-guidelines/content-removal-guidelines) 
+* [Merging an entry](/docs/other-guidelines/merging-entries)
+* Creating and editing "featured songlists"
+* Managing [entry reports](/docs/pinned/entry-reports)
+* Approving an entry (and editing them)
 
 ## Things to remember
 
 We expect you to know the basic guidelines on VocaDB, and most importantly, ask the other members if you're unsure of something.
 
 Here are some things to keep in mind:
-* Trusted users are not moderators. Skip moderation-related entry reports such as [artist verification](/docs/artists/artist-verification) and [content removal](/docs/other-guidelines/content-removal-guidelines) -requests.
+* Trusted users are not moderators. Skip moderation-related entry reports such as [artist verification](/docs/artists/artist-verification) and [content removal](/docs/other-guidelines/content-removal-guidelines) requests.
 * Before [merging entries](/docs/other-guidelines/merging-entries), keep in mind that undoing a merge, especially merging artist entries, can be a lot of work, so please make sure the entries really need to be merged.
 * Being a trusted user doesn't mean that you're above others. Please try to listen to advice given by other members, especially those who have been on the site longer than you.
 * Avoid assuming things without proof or reference. VocaDB is intended to be a reliable source of information. When working on a database/encyclopedia it's better to be safe than sorry. If you have to assume, at least make it clear that there is no reference.
 * Avoid fights or personal insults in the public entry comment sections. Personal arguments are to be resolved elsewhere. AKA no drama.
 * Communicate! If you're unsure, post a question in the comments. If you find something to be improved, or disagree with our rules, post your opinion in the comments (but avoid unnecessary, pointless arguing). Note that ignoring others, (especially staff members), doesn't work in the long run. If you're being harassed, message a staff member.
+* The [entry reports](https://vocadb.net/Admin/ViewEntryReports) page is for reports themselves; they are **NOT just notifications**. The exclaimation point and number under the "Account" menu are there to let you know that there are active reports that need to be addressed. If you dislike this feature, you may use the [Stylus](https://github.com/openstyles/stylus/) extension and install [this script](https://userstyles.world/style/19593/hide-vdb-notifs) by Shiroizu. **Do not close them** unless they have been fixed or otherwise addressed. 
 
 Also see the [editing FAQ](/docs/pinned/vocadb-editing-faq) and [User groups](/docs/documentation/user-groups).
 
 ## How to become trusted user?
 
-There is no specific criteria for becoming a trusted user. It is based on the time spent on the website, number and especially quality of edits. A small number of detailed edits can be reason enough for becoming trusted. Communication also matters. We expect trusted users to be sufficiently respectful, play nice with others, and ask someone senior if they're unsure of something. That also means taking responsibility of correcting any mistakes with your edits, when someone points them out.
+There is no specific criteria for becoming a trusted user. It is based on the time spent on the website, number and especially quality of edits. A small number of detailed edits can be reason enough for becoming trusted. Communication also matters. We expect trusted users to be sufficiently respectful, avoid arguments with other users, and ask someone senior if they're unsure of something. That also means taking responsibility of correcting any mistakes with your edits when someone points them out.
 
 Please don't ask us to promote you to trusted. Eventually a staff member (moderator or administrator) will notice your edits, make a short review and promote you if they're satisfied. If they're unsure, they will contact you and/or other staff members first.


### PR DESCRIPTION
1. Add that it's preferred to wait 24 hours for most entry reports
2. Add that it's encouraged to point out exactly what the error is rather than making vague statements
3. Add the permissions that trusted users gain on the trusted users page.
4. Add disclaimer about the entry reports page and linked the script to hide the nags if people want it
5. Changed a little bit of odd wording/punctuation