### PR TITLE
Move related rule to same paragraph

### DIFF
--- a/src/content/docs/Song entry editing.mdx
+++ b/src/content/docs/Song entry editing.mdx
@@ -173,9 +173,9 @@ Remember to also credit the vocalists for Music PVs. Silent characters (that hav
 
 Music PVs should always be derived from an original entry. If the song was originally published with the PV, then include the PV in the original song entry rather than making a separate page.
 
-Only the official PV should be added to the original song entry. Major derivative PVs by unrelated artists should have their own entries. Additional official PVs with major differences should also have separate entries.
+Only the official PV should be added to the original song entry. Major derivative PVs by unrelated artists should have their own entries. Additional official PVs with major differences should also have separate entries, but minor differences like model changes can be included in the original entry with the "other" media/PV type.
 
-If the song was published without a PV and an official PV is released later, add the PV to the original song entry. Minor differences like model changes can be included in the original entry with the "other" type.
+If the song was published without a PV and an official PV is released later, add the PV to the original song entry.
 
 **Rules for Music PVs**:
 


### PR DESCRIPTION
The "Additional official PVs" rule and "minor differences" try to disambiguate whether music PV should be added to the original or to a new entry when there is a difference to an existing PV.

The "published without a PV" rule disambiguate whether music PV should be added to the original or to a new entry when there is no existing PV. 

This PR moves related rules (the two former) to the same paragraph.

Noticed this when looking into the [Project Sekai 3DMV proposal](https://discord.com/channels/309072240639737866/1320393300397523004/1329969357257707622).