### PR TITLE
Fix mistake in Tags page

### DIFF
--- a/src/content/docs/Tags.mdx
+++ b/src/content/docs/Tags.mdx
@@ -28,8 +28,8 @@ Adding tag votes to objective tags is redundant, unless there is a need to "high
 ## Creating and editing tags
 
 Every tag should reflect some well-defined concept. For this reason, tag entries **must** have:
-- External links (for verification that the concept is recognized / well defined)
-- A description (to clearly state the tag's purpose)
+- External links (Showing that the concept is recognized/well defined, **not required for tags in the "editor notes" category.**)
+- A description (which should clearly state the tag's purpose)
 - A category 
 - Usage on **at least one** entry (besides for tags of the "Copyright" category, whose [requirements are different](/docs/secondary-entry-types/tags#copyrights)).
 


### PR DESCRIPTION
add exemption for tags of "editor notes" category (external links requirement) 