### PR TITLE
Minor addition, update and standardization

### DIFF
--- a/src/content/docs/External links.mdx
+++ b/src/content/docs/External links.mdx
@@ -70,7 +70,7 @@ Adding links with different URL formats is encouraged because they can be useful
 
 ## Forbidden links
 
-**Direct** download links to files (for example .mp3 or .flac) or Google Drive links are not allowed, even if they're legal. Instead, you should always link to the artist's page if possible, be that Piapro or a blog. There are multiple reasons for this, but the most important is that the artist gets traffic for the downloads.
+**Direct** download links to media files (such as .mp3 or .flac) and links to file-hosting services (such as Google Drive or Dropbox) are not allowed, even if they're legal. If the content is officially distributed, link the artist's page (e.g., on Piapro or a blog) instead. There are multiple reasons for this, but the most important is that the artist gets traffic for the downloads.
 
 Links to illegal file sharing sites are not allowed.
 

--- a/src/content/docs/Song entry editing.mdx
+++ b/src/content/docs/Song entry editing.mdx
@@ -502,8 +502,7 @@ Premieres (mostly on YouTube) that are not fully available should not be added t
 Usually, this is the artist themselves or someone uploading on their behalf. If this is the case, and it's not obvious how the upload was authorized, please clarify this in the edit notes.
 
 - Usually, one original PV per service.
-- Mark as "Unavailable" if deleted or hidden by the author, but not for region-blocked content.
-Original PV links can be marked as "Unavailable" if the PV is deleted or hidden by the author and thus **unplayable**. Watch out for [region-blocked](https://vocadb.net/T/8226/region-blocked) content, which **should not** be marked as "Unavailable".
+- Mark as "Unavailable" if deleted, hidden by the author, or unavailable worldwide. If only available in certain regions, **do not** mark as "Unavailable". You can check the availability using the [YouTube region restriction checker](https://polsy.org.uk/stuff/ytrestrict.cgi).
 - When adding deleted PVs, it is possible to use a **Nicolog** (Nicovideo archival service) link instead of the nicovideo.jp link. This can be accomplished by replacing the "nicovideo" in the URL with "nicolog". If a Nicolog archive of the PV exists, relevant data (duration, publish date, tags, vocalists, author) will be automatically added, as with normal PVs. 
 
 #### Reprint

--- a/src/content/docs/Song entry editing.mdx
+++ b/src/content/docs/Song entry editing.mdx
@@ -549,7 +549,7 @@ For subsequent fixes by other users, the fixer name should be appended to the so
   - "From MikuWiki (edited by user2)"
   - "From MikuWiki (edited by user2, user3)"
 
-If the lyric source is missing, locate it before modifying the lyrics. If the source can't be found, create an entry report for the missing source and use a credit like "Unknown (fixed by user2)".
+If the lyric source is missing, locate it before modifying the lyrics. See [a list of websites where to look for lyrics](/docs/other/useful-related-informational-sites#song-lyrics). If the source can't be found, create an entry report for the missing source and use a credit like "Unknown (fixed by user2)".
 
 ## Update Notes
 

--- a/src/content/docs/Song entry editing.mdx
+++ b/src/content/docs/Song entry editing.mdx
@@ -285,7 +285,7 @@ Links to lyrics should be added to the "Lyrics" tab instead.
 
 Duplicating album and artist links in song entries is **redundant**.
 
-Direct download links to media files (such as .mp3) are generally not allowed, even if they're official and legal. If the song/video is officially distributed, link to the artist's official download page (e.g., on Piapro) instead.
+**Direct** download links to media files (such as .mp3 or .flac) and links to file-hosting services (such as Google Drive or Dropbox) are not allowed, even if they're legal. If the content is officially distributed, link the artist's page (e.g., on Piapro or a blog) instead.
 
 - [External links](/docs/other-guidelines/external-links)
 


### PR DESCRIPTION
1st commit: Added a reference to the page on VocaDB Wiki that lists lyrics-hosting websites.
Discussed on [VocaDB's Discord server](https://discordapp.com/channels/309072240639737866/1231105886047436811/1348576654225702952)
2nd commit: Updated the paragraph related to PVs being unavailable.
Discussed on [VocaDB's Discord server](https://discordapp.com/channels/309072240639737866/1231105886047436811/1339208874611310685)
3rd commit: Standardized guidelines on different pages regarding direct download links and links to file-hosting services.