### PR TITLE
VocaDB front-end only development.

### DIFF
--- a/src/content/docs/Development environment (Linux).mdx
+++ b/src/content/docs/Development environment (Linux).mdx
@@ -1,6 +1,6 @@
 ---
 title: Development environment (Linux)
-description: Guide for setting up a VocaDB development environemnt on Linux
+description: Guide for setting up a VocaDB development environment on Linux
 parent: Development
 tags: ["wikipage", "development", "github", "documentation", "vocadb"]
 ---

--- a/src/content/docs/Development environment (Windows).mdx
+++ b/src/content/docs/Development environment (Windows).mdx
@@ -1,6 +1,6 @@
 ---
 title: Development environment (Windows)
-description: Guide for setting up a VocaDB development environemnt on Windows
+description: Guide for setting up a VocaDB development environment on Windows
 parent: Development
 tags: ["wikipage", "development", "github", "documentation", "vocadb"]
 ---
@@ -34,7 +34,7 @@ tags: ["wikipage", "development", "github", "documentation", "vocadb"]
    cd vocadb
    ```
 
-3. Open the VocaDB project on Visual Studio.
+3. Open the VocaDB project in Visual Studio.
 4. Prepare the configuration files. See [web.config](#webconfig) section for more information.
 5. Prepare the database. See [Database configuration](#database-configuration) section for more information.
 
@@ -187,7 +187,7 @@ npm install
 Run this command so that Vite will automatically recompile your assets when it detects a change.
 
 ```bash
-npm run dev
+npm run development
 ```
 
 In some cases, you need to build it first so that the changes will be reflected on the website.

--- a/src/content/docs/Front-end only development environment.mdx
+++ b/src/content/docs/Front-end only development environment.mdx
@@ -1,0 +1,77 @@
+---
+title: Front-end only development environment
+description: Guide for setting up a VocaDB development environment for front-end development only
+parent: Development
+tags: ["wikipage", "development", "github", "documentation", "vocadb"]
+---
+
+This guide is to start developing on vocaDB front-end only.
+This bypasses the need to set up the back-end, run the server locally and set up a database.
+By connecting to the VocaDB [beta website](https://beta.vocadb.net/) you are able to develop locally with minimal setup.
+Do mind that if you have only recently created your account, it might not yet be available on the beta website and you will be unable to log in. Any other functionality should work as expected.
+
+## Requirements
+
+- Visual Studio Code
+  - Extensions:
+    - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+    - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- [Node.js](https://nodejs.org/) v12.18.3 (or latest LTS) with NPM.
+
+## Step-by-step first setup
+
+1. Ensure you have all the requirements installed.
+2. Clone the repository and its submodules.
+
+   ```bash
+   git clone https://github.com/vocadb/vocadb.git --recurse-submodules
+   cd vocadb
+   ```
+
+3. Open the VocaDB project in Visual Studio.
+4. Prepare the vite configuration file. See [vite.config](#viteconfig) section for more information.
+5. Build the frontend using Node.js. See [Compiling frontend assets](#compiling-frontend-assets) section for more information.
+
+   1. Right click `VocaDbWeb` on the Solution Explorer in the right and select the <kbd>Open in Terminal</kbd> option.
+   2. Install dependencies by running `npm install` on the Terminal.
+   3. Build assets by running `npm run development` on the Terminal.
+
+6. You should now be able to start developing.
+
+## Formatting
+
+Line endings and indentation are configured by [EditorConfig](http://editorconfig.org/). There's a plugin for almost any major IDE/text editor. Please install that plugin before editing the code files.
+
+For the frontend located on `VocaDbWeb`, Prettier and ESLint is used to ensure code quality. You can use plugins to enhance the use of them.
+
+### Visual Studio Code
+
+The following extensions are recommended in the `VocaDbWeb` folder.
+
+  - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) by [Dirk Baeumer](https://marketplace.visualstudio.com/publishers/dbaeumer)
+  - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) by [Prettier](https://marketplace.visualstudio.com/publishers/esbenp)
+
+These configuration is recommended for better formatting on Visual Studio Code. Open the Settings screen (by pressing <kbd>F1</kbd> and press <kbd>Preferences: Open Settings (UI)</kbd> or <kbd>File</kbd> (on the top left) > <kbd>Preferences</kbd> > <kbd>Settings</kbd>) and change these settings.
+
+- **Editor: Default Formatter**: <kbd>Prettier - Code formatter <small>esbenp.prettier-vscode</small></kbd>
+- **Editor: Format on Save**: *checked*
+
+## vite.config
+
+Navigate to `VocaDbWeb\vite.config.ts`. Here you will see a configuration file that currently points to `'https://localhost:5001'` in two locations locations. Replace the value with `'https://beta.vocadb.net'` to connect to the VocaDB beta server.
+
+## Compiling frontend assets
+
+Ensure Node.js is installed and `VocaDbWeb` is opened on the Terminal of Visual Studio Code before running these commands.
+
+Install the frontend dependencies by running this command.
+
+```bash
+npm install
+```
+
+Run this command so that Vite will automatically recompile your assets when it detects a change.
+
+```bash
+npm run development
+```


### PR DESCRIPTION
This is a minimal version of the Development environment guide that instructs the user how to set up local development for VocaDB for the front-end only. This bypasses the need to set up the back-end, server and database locally and uses the beta website to be able to quickly start developing. Guide should be OS agnostic.

This information is currently only available by searching through the discord history, which isn't a very straightforward process. It would serve better to be put on the wiki.

I've also taken the liberty to fix some stray typos in both the existing Development environment documents and correct the incorrect `npm run dev` command in the windows dev env document to `npm run development`.