### PR TITLE
Update static file domains

### DIFF
--- a/src/content/docs/Domains and login process.mdx
+++ b/src/content/docs/Domains and login process.mdx
@@ -8,8 +8,8 @@ tags: ["wikipage", "documentation", "user", "vocadb"]
 ## Domains
 * Main domain: https://vocadb.net (www.vocadb.net is an alias)
 * Static files: 
-  * https://vocadb.t3.storage.dev (primary)
-  * https://static.vocadb.net (fallback)
+  * https://static.vocadb.net (primary)
+  * https://vocadb.t3.storage.dev ([Tigris](https://www.tigrisdata.com/) storage bucket)
 * Test instance (future branch): https://beta.vocadb.net
 
 ### SSL domain


### PR DESCRIPTION
I saw that it now uses the `vocadb.t3.storage.dev` domain for the static files, so I did this change.

When creating the changes, I'm making my own assumptions. **Please check again based on the real implementation.**