### PR TITLE
Remove blue when a nav link is visited

### DIFF
--- a/src/components/navigation/NavContents.tsx
+++ b/src/components/navigation/NavContents.tsx
@@ -15,7 +15,7 @@ export function NavContents({ mobile = false }: NavContentsProps) {
     mobile ? "space-y-3 pb-6" : "space-y-1 pb-4 text-sm",
   );
   const buttonClass = mobile ? "py-1.5" : "py-1";
-  const linkClass = "hover:underline visited:text-blue-500";
+  const linkClass = "hover:underline";
 
   return (
     <>


### PR DESCRIPTION
This PR removes the blue color when a navigation link (on the left sidebar) is visited. One reason is that I don't really like it (it is unusual), and it makes it consistent on other links on the wiki.

If you want to vote, you can do it here (use :+1: or :-1:) or [the Discord message](https://discord.com/channels/309072240639737866/1231105886047436811/1438563117700354119).