### PR TITLE
Clarify (and expand) "Fully loanword names" rule

### DIFF
--- a/src/content/rules/fully-loanword-names.mdx
+++ b/src/content/rules/fully-loanword-names.mdx
@@ -21,11 +21,11 @@ excerpt: Do not add the romanization if the entire name is composed of loanwords
 import { Alert } from "@/components/ui/alert";
 import { BoxGroup } from "@/components/Box";
 
-The romanization of the Non-English name should not be added as a primary name or the alias.
+The romanization of the non-English name should not be added as a primary name or the alias.
 
-If the entire non-English primary name is composed of loanwords, the romanized primary name must be left empty, leaving the English primary name filled for the translation.
+If the entire non-English primary name is composed of loanwords, the Romanized primary name must be left empty, leaving the English primary name filled for the translation.
 
-If an alias is composed of loanwords, the romanized alias must not be added.
+If an alias is composed of loanwords, the Romanized alias must not be added.
 
 ## Examples
 


### PR DESCRIPTION
I tried to clarify this rule by giving examples and mentioning the exact fields to be left empty/filled. I also try to expand this for alias names, if there is such case.