### PR TITLE
Update modified date for "Prioritize official translations" rule

### DIFF
--- a/src/content/rules/prioritize-official-translations.mdx
+++ b/src/content/rules/prioritize-official-translations.mdx
@@ -10,7 +10,7 @@ detection_script:
 edit_list:
 date_checked:
 date_created:
-date_modified:
+date_modified: 2025-12-16
 rationale:
 status: Active
 rule_context: Romanization


### PR DESCRIPTION
This PR updates the modified date, since #66 has been merged. I haven't updated the modified date of the rule due to the long turnaround of the PR.