### PR TITLE
Clarify PV type/classification rules and docs (2)

### DIFF
--- a/src/content/docs/Song entry editing.mdx
+++ b/src/content/docs/Song entry editing.mdx
@@ -354,9 +354,9 @@ Japanese: 調声
 
 ## Tab 3: Media
 
-Songs may contain any number of embedded media files (Promotional Videos = PVs) on Niconico (NND), YouTube, Bilibili, Vimeo, or audio streams on Piapro or SoundCloud. The supported media services are fully listed [here](/docs/supported-streaming-services).
+Songs may contain any number of links/embeds to a media/PV (promotional video) to any of [the supported media/streaming services](/docs/supported-streaming-services).
 
-All embeds should have the same version of the song (except for unrelated [intros](https://vocadb.net/T/6334/unrelated-intro) and [outros](https://vocadb.net/T/6494/unrelated-outro)).
+All media/PVs should have [the same version of the audio/song](/rules/same-audio) (except for unrelated [intros](https://vocadb.net/T/6334/unrelated-intro) and [outros](https://vocadb.net/T/6494/unrelated-outro)).
 
 <BoxGroup>
   <RuleEmbed ruleId={131} />
@@ -365,7 +365,7 @@ All embeds should have the same version of the song (except for unrelated [intro
   <RuleEmbed ruleId={135} />
 </BoxGroup>
 
-### PV types
+### Media/PV types
 
 <RuleEmbed ruleId={133} />
 
@@ -376,7 +376,7 @@ All embeds should have the same version of the song (except for unrelated [intro
   <RuleEmbed ruleId={162} />
 </BoxGroup>
 
-Usually, the artist uploads it in multiple services (Niconico, YouTube, etc.). You should check other accounts to see if this is the case.
+Usually, the same media/PV is uploaded in multiple services (Niconico, YouTube, etc.). You should check other accounts to see if this is the case.
 
 If a Nicolog archive of a deleted PV exists, relevant data (duration, publish date, tags, vocalists, author) will be automatically added, as with normal PVs. This can be accomplished by replacing the "nicovideo" in the URL with "nicolog".
 

--- a/src/content/rules/original-pv-classification.mdx
+++ b/src/content/rules/original-pv-classification.mdx
@@ -22,9 +22,9 @@ excerpt: Original PVs are authorized content uploaded by a party with rights to 
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 import { BoxGroup } from "@/components/Box.tsx";
 
-The Original PV type is used for authorized content uploaded by a party with rights to both audio and video.
+The Original media/PV type is used for authorized content uploaded by a party with rights to both audio and video.
 
-Usually, this is the artist/producer themselves or someone uploading on their behalf. In case this is not obvious how the upload was authorized, clarify this in the update notes.
+Usually, this is the artist/producer themselves or someone uploading on their behalf. In case it is not obvious how the upload was authorized, clarify this in the update notes.
 
 See [the respective section on the Song entry editing page](/docs/song-entry-editing#original) for more information.
 

--- a/src/content/rules/other-pv-classification.mdx
+++ b/src/content/rules/other-pv-classification.mdx
@@ -21,9 +21,9 @@ excerpt: Other PVs are subtitled PVs or modified PVs that don't justify a new en
 
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 
-The Other PV type is used for subtitled PVs or PVs modified from the original that don't justify a new entry.
+The Other media/PV type is used for subtitled PVs or PVs modified from the original that don't justify a new entry.
 
-For some songs, only "Other" type PVs may exist, where an authorized/official PV is not available. This is common for album-only songs.
+For some songs, only PVs with this type may exist, where an authorized/official PV is not available. This is common for album-only songs.
 
 The audio should still be the same as the original (see [Rule: Same audio](/rules/same-audio)).
 

--- a/src/content/rules/reprint-pv-classification.mdx
+++ b/src/content/rules/reprint-pv-classification.mdx
@@ -16,15 +16,15 @@ rationale:
 status: Active
 rule_context:
 mikumod_support: "False"
-excerpt: Reprint PVs are copies original from another service by a party unrelated to the original artist.
+excerpt: Reprint PVs are copies of the original from another service by a party unrelated to the original artist.
 ---
 
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 import { BoxGroup } from "@/components/Box.tsx";
 
-The Reprint PV type is used for uploads of the original PV from another service by a party unrelated to the original artist.
+The Reprint media/PV type is used for uploads of the original PV from another service by a party unrelated to the original artist.
 
-It should be identical to the original (music, vocals, length, and video). If any of these are changed, use the "Other" type, or create another (music PV) entry if appropriate.
+It should be identical to the original (music, vocals, length, and video). If any of these are changed, use the "Other" type, or create another Music PV entry if appropriate.
 
 See [the respective section on the Song entry editing page](/docs/song-entry-editing#reprint) for more information.
 

--- a/src/content/rules/same-audio.mdx
+++ b/src/content/rules/same-audio.mdx
@@ -17,8 +17,9 @@ status: Active
 rule_context:
 mikumod_support: "Planned"
 relevant_tag_id: 12082
+except: All media/PVs in an song entry must have the same audio, except for unrelated intros or outros.
 ---
 
-All PVs in the song entry should have the same audio and roughly the same song length.
+All media/PVs added in a single song entry must have the same audio and roughly the same song length.
 
 [Unrelated intros](https://vocadb.net/T/6334) and [outros](https://vocadb.net/T/6494/unrelated-outro) are an exception to this.

--- a/src/content/rules/use-the-correct-pv-types.mdx
+++ b/src/content/rules/use-the-correct-pv-types.mdx
@@ -22,7 +22,7 @@ excerpt: Use the correct PV type between [Original](/rules/original-pv-classific
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 import { BoxGroup } from "@/components/Box.tsx";
 
-For each PV/media on any applicable entry, choose the correct type. There are three available types: [Original](/rules/original-pv-classification), [Reprint](/rules/reprint-pv-classification), and [Other](/rules/other-pv-classification).
+For each media/PV added on a song entry, choose the correct type. There are three available types: [Original](/rules/original-pv-classification), [Reprint](/rules/reprint-pv-classification), and [Other](/rules/other-pv-classification).
 
 <BoxGroup>
   <RuleEmbed ruleId={161} />
@@ -30,4 +30,4 @@ For each PV/media on any applicable entry, choose the correct type. There are th
   <RuleEmbed ruleId={164} />
 </BoxGroup>
 
-For more information, see [the respective section on the Song entry editing page](/docs/song-entry-editing#pv-types) or the respective rule pages for each type (click the title).
+For more information, see [the respective section on the Song entry editing page](/docs/song-entry-editing#pv-types) or the respective rule pages for each type (by clicking on the rule title).


### PR DESCRIPTION
Continuation of #76 

- Add and adjust "media" keyword ("PV" doesn't exist on the VocaDB interface, could be confusing)
- Shorten excerpt for "Same audio"
- Remove duplicate mention of supported streaming service 
- Typo and clarity fixes