### PR TITLE
Update website changelog

### DIFF
--- a/src/content/docs/Website Changelog.mdx
+++ b/src/content/docs/Website Changelog.mdx
@@ -323,3 +323,84 @@ For information on the feature requests and bug reports, see the [VocaDB feature
 ### Fixes
 
 - Tooltips now show the correct info after backwards navigation (#1378)
+
+## 25 March 2025
+
+### Improvements
+
+- An artist verification link is now available in the sidebar for eligible users ([#1887](https://github.com/VocaDB/vocadb/issues/1887))
+- The maximum length for entry reports has been increased ([#1909](https://github.com/VocaDB/vocadb/issues/1909))
+- The 1-hour time limit for editing reports has been removed for Trusted+ users ([#1909](https://github.com/VocaDB/vocadb/issues/1909))
+- Added Amdo Tibetan as a language option ([#1901](https://github.com/VocaDB/vocadb/issues/1901))
+- Weblink name changes and new translations ([#1904](https://github.com/VocaDB/vocadb/issues/1904))
+
+## 28 April 2025
+
+### Improvements
+
+- New and updated web link matchers ([#1924](https://github.com/VocaDB/vocadb/issues/1924))
+- New translations added ([#1920](https://github.com/VocaDB/vocadb/issues/1920))
+
+### Fixes
+
+- Resolved a query issue related to release events ([#1917](https://github.com/VocaDB/vocadb/issues/1917))
+
+## 2 July 2025
+
+### Improvements
+
+- Happy Pride Month! Added a new Pride theme.
+- Added a full Dutch translation ([#1960](https://github.com/VocaDB/vocadb/issues/1960))
+- New web link matcher for Vocaloid Lyrics Wiki (Miraheze) ([#1963](https://github.com/VocaDB/vocadb/issues/1963))
+- Added Sakha as a language option ([#1957](https://github.com/VocaDB/vocadb/issues/1957))
+
+### Fixes
+
+- Corrected an issue causing related album thumbnails to be blank ([#1925](https://github.com/VocaDB/vocadb/issues/1925))
+- Applied a special display fix for iOS devices
+
+## 15 October 2025
+
+### Improvements
+
+- Added Bashkir and Tatar as language options ([#1972](https://github.com/VocaDB/vocadb/issues/1972))
+- New translations ([#1973](https://github.com/VocaDB/vocadb/issues/1973))
+
+## 27 October 2025
+
+### Improvements
+
+- Performance improvements for faster image loading
+
+## 9 November 2025
+
+### Improvements
+
+- Use new S3-based storage backend for static files (images and songs)
+- Added rate limiting on details pages ([#1830](https://github.com/VocaDB/vocadb/issues/1830))
+- New "Invalid tag usage" report type ([#1831](https://github.com/VocaDB/vocadb/issues/1831))
+
+### Fixes
+
+- Replaced outdated `/Help` links with new links to the wiki ([#1822](https://github.com/VocaDB/vocadb/issues/1822), [#1814](https://github.com/VocaDB/vocadb/issues/1714))
+- Correctly parse time cutoffs for statistics ([#1824](https://github.com/VocaDB/vocadb/issues/1824), [#1816](https://github.com/VocaDB/vocadb/issues/1816))
+- Fixed ongoing events not included in the "Happening now" section on the front page ([#1839](https://github.com/VocaDB/vocadb/issues/1839))
+
+## 23 December 2025
+
+### Improvements
+
+- Upgrade to .NET 8 ([#1999](https://github.com/VocaDB/vocadb/issues/1999))
+- New translations ([#1974](https://github.com/VocaDB/vocadb/issues/1974))
+- Artist and album pictures are now served from the new storage backend
+
+### Fixes
+
+- Removed Amazon affiliate links
+- Fixed a scrolling issue in the main application container
+
+## 27 December 2025
+
+### Improvements
+
+- New "Band/unit" artist type


### PR DESCRIPTION
This PR updates the website changelog, including the changes from after the latest changelog on February, to the date this PR is made. It is based on 
- commits made after 8 February 2025 (commits after VocaDB/vocadb@77ac1fa94f795f3810552bc41af7afd403cec395)
- website update maintenance annoucements made on the Discord channel (for release date sync)
- some general observation and notes from the activity of the site and the Discord server.

## Notes

- Some dates doesn't have an appropriate website update maintenance announcement on the Discord channel. Please check whether the dates are accurate.
- Some changes may not be reflected on the commits (such as the force change of TetoDB on April Fools 2025, which I'd assume it is the case on 2024 but not mentioned on the changelog, hence not added on the changelog, and the recent Band/unit artist type addition).
- Generative AI is used for ensure linguistic similarity to the previous changelog entries.

## TODO (for staff)

- [ ] Check whether the written changelog is accurate
- [ ] Check whether that all notable changes have been mentioned