### PR TITLE
Use .NET 8 after recent upgrade

### DIFF
--- a/src/content/docs/Development environment (Linux).mdx
+++ b/src/content/docs/Development environment (Linux).mdx
@@ -26,7 +26,7 @@ cd vocadb
 
 go to https://code.visualstudio.com/ and download for linux.
 
-## Install .net 7
+## Install .net 8
 
 make sure your system installed the [.net dependencies and requirements](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#dependencies).
 
@@ -172,7 +172,7 @@ connection string example:
 
 if you encounter an error related to kerberos, you may need to update the connection string with `integrated security=false;`.
 
-for other errors, you may need to install the .net 5 sdk to perform the migration. although it should work with .net 7.
+for other errors, you may need to install the .net 5 sdk to perform the migration. although it should work with .net 8.
 
 for more information see [starting with fluentmigrator](https://fluentmigrator.github.io/articles/quickstart.html?tabs=runner-dotnet-fm).
 

--- a/src/content/docs/Development environment (Windows).mdx
+++ b/src/content/docs/Development environment (Windows).mdx
@@ -21,7 +21,7 @@ tags: ["wikipage", "development", "github", "documentation", "vocadb"]
     - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - IIS or IIS Express
   - Static files support
-- .NET 7 SDK. or higher
+- .NET 8 SDK. or higher
 - [Node.js](https://nodejs.org/) v12.18.3 (or latest LTS) with NPM.
 
 ## Step-by-step first setup


### PR DESCRIPTION
Based on changes on https://github.com/VocaDB/vocadb/commit/d2fe06c36599530682ccbdae55cdbbbac4758f3d