### PR TITLE
Remove modified date for "Prioritize official translations" rule

### DIFF
--- a/src/content/rules/prioritize-official-translations.mdx
+++ b/src/content/rules/prioritize-official-translations.mdx
@@ -10,7 +10,7 @@ detection_script:
 edit_list:
 date_checked:
 date_created:
-date_modified: 2025-12-16
+date_modified:
 rationale:
 status: Active
 rule_context: Romanization


### PR DESCRIPTION
Reverts #74, since [Shiroizu said it is not needed](https://discord.com/channels/309072240639737866/1231105886047436811/1451635161539149958).