### PR TITLE
Redirect rule pages by ID instead of rewrite

### DIFF
--- a/src/layouts/DocRedirect.astro
+++ b/src/layouts/DocRedirect.astro
@@ -1,0 +1,21 @@
+---
+import Redirect from "./Redirect.astro";
+
+interface FrontMatter {
+  title?: string;
+  description?: string;
+  tags?: string[];
+}
+
+export interface Props {
+  frontmatter?: FrontMatter;
+  canonical: string;
+}
+
+const { frontmatter = {}, canonical } = Astro.props;
+
+const title = frontmatter?.title;
+const description = frontmatter?.description;
+---
+
+<Redirect title={title} description={description} canonical={canonical} />

--- a/src/layouts/Redirect.astro
+++ b/src/layouts/Redirect.astro
@@ -1,0 +1,69 @@
+---
+import {
+  SITE_TITLE,
+  SITE_DESCRIPTION,
+  SITE_DEFAULT_OG_IMAGE,
+} from "../site_config";
+import "@/styles/globals.css";
+
+export interface Props {
+  title?: string;
+  description?: string;
+  thumbnail?: {
+    src: string;
+    alt: string;
+  };
+  from?: string;
+  canonical?: string;
+}
+
+const {
+  title = SITE_TITLE,
+  description = SITE_DESCRIPTION,
+  thumbnail = {
+    src: SITE_DEFAULT_OG_IMAGE,
+    alt: SITE_TITLE,
+  },
+  from = Astro.request.url,
+  canonical,
+} = Astro.props;
+
+const siteURL = Astro.site;
+const absoluteLocation = siteURL
+  ? new URL(canonical || "", siteURL)
+  : canonical;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={absoluteLocation} />
+
+    <meta property="og:title" content={title} />
+    <meta property="og:type" content="website" />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={thumbnail.src} />
+    <meta property="og:url" content={canonical} />
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <meta http-equiv="refresh" content={`0;url=${canonical}`} />
+    <meta name="robots" content="noindex" />
+  </head>
+
+  <body>
+    <a href={canonical}
+      >Redirecting {
+        from ? (
+          <>
+            from <code>${from}</code>{" "}
+          </>
+        ) : (
+          ""
+        )
+      }to <code>{canonical}</code></a
+    >
+  </body>
+</html>

--- a/src/pages/rules/[id].astro
+++ b/src/pages/rules/[id].astro
@@ -1,0 +1,46 @@
+---
+import { getCollection, type CollectionEntry } from "astro:content";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import stripMarkdown from "strip-markdown";
+import remarkStringify from "remark-stringify";
+import DocRedirect from "@/layouts/DocRedirect.astro";
+
+export async function getStaticPaths() {
+  const ruleEntries: CollectionEntry<"rules">[] = await getCollection("rules");
+  const paths = [];
+
+  for (const entry of ruleEntries) {
+    paths.push({
+      params: {
+        id: entry.data.id,
+      },
+      props: { entry },
+    });
+  }
+
+  return paths;
+}
+
+const { entry } = Astro.props;
+
+async function stripText(markdownInput: string) {
+  const file = await unified()
+    .use(remarkParse)
+    .use(stripMarkdown)
+    .use(remarkStringify)
+    .process(markdownInput);
+
+  return String(file);
+}
+
+const description = await stripText(entry.data.excerpt || entry.body);
+---
+
+<DocRedirect
+  frontmatter={{
+    title: `Rule: ${entry.data.name}`,
+    description: description,
+  }}
+  canonical={"/rules/" + entry.slug}
+/>

--- a/src/pages/rules/[slug].astro
+++ b/src/pages/rules/[slug].astro
@@ -18,23 +18,12 @@ export async function getStaticPaths() {
   const paths = [];
 
   for (const entry of ruleEntries) {
-    const pathConfig = {
+    paths.push({
       params: {
         slug: entry.slug,
       },
       props: { entry },
-    };
-
-    paths.push(pathConfig);
-
-    if (typeof entry.data.id === "number") {
-      paths.push({
-        params: {
-          slug: entry.data.id.toString(),
-        },
-        props: { entry },
-      });
-    }
+    });
   }
 
   return paths;
@@ -44,8 +33,6 @@ const { entry } = Astro.props;
 const { headings } = await entry.render();
 
 headings.push({ depth: 2, slug: "metadata", text: "Metadata" });
-
-const isNumericRoute = !isNaN(Number(Astro.params.slug));
 
 async function stripText(markdownInput: string) {
   const file = await unified()
@@ -73,19 +60,7 @@ const description = await stripText(entry.data.excerpt || entry.body);
   headings={headings}
   filePath={"src/content/rules/" + entry.id}
   pagePath={"rules/" + entry.slug}
-  pagefindIgnore={isNumericRoute}
 >
-  <script
-    define:vars={{ slug: entry.slug, currentPath: Astro.params.slug }}
-    is:inline
-  >
-    // Redirect to canonical URL if accessed via numeric ID
-    if (currentPath !== slug && !isNaN(Number(currentPath))) {
-      const newUrl = window.location.pathname.replace(/\/[^\/]+$/, `/${slug}`);
-      window.history.replaceState({}, "", newUrl);
-    }
-  </script>
-
   <RuleEmbed rule={entry} fields={"All"} />
 
   {content && <content.Content />}


### PR DESCRIPTION
One part of the implementation of better redirect system instead of the long `astro.config.js` redirect list and the URL rewrite of rule pages. Builds faster, and it is a proper redirect.

It is done like this to maintain the meta tags for social media sharing, though untested.