### PR TITLE
Add practical definition for "Cover classification" rule

### DIFF
--- a/src/content/rules/cover-classification.mdx
+++ b/src/content/rules/cover-classification.mdx
@@ -24,9 +24,9 @@ excerpt: The "Cover" song type is used for re-recorded versions of a song.
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 import { BoxGroup } from "@/components/Box.tsx";
 
-A **cover** (カバー曲) is a re-recorded version of a song, usually by a different artist.
+A **cover** (カバー曲) is a re-recorded version of a song, usually by a different artist. In the voice synth world, covers often use a different voicebank while keeping the instrumentals intact. Sometimes, a cover is another artist's interpretation of the song.
 
-In the voice synth world, covers often use a different voicebank while keeping the instrumentals intact.
+Pratically, in VocaDB, a **cover** is a derivative of a song where vocals are different than the original version of the song. The instrumental is kept intact, though it is possible to [replicate the instruments](https://vocadb.net/T/4709/replicated-instrumental) while using this song type in VocaDB.
 
 The "[self-cover](https://vocadb.net/T/391)" tag is for songs where the original artist covered their own song.
 


### PR DESCRIPTION
The current definition still relatively generic in the context of VocaDB. This practical definition is added to clear the definition based on how it is usually been used.