### PR TITLE
Clarify "Specify original" and adjacent OoS rule

### DIFF
--- a/src/content/rules/specify-original.mdx
+++ b/src/content/rules/specify-original.mdx
@@ -18,23 +18,21 @@ rule_context:
 mikumod_support: "Planned"
 relevant_tag_id: 4631
 excerpt: >
-  For derived songs, refer the original by...
-    - adding the song entry on the "Original version" field
-    - adding the UtaiteDB/TouhouDB entry as an external link
-    - following [the "Specify out-of-scope original" rule](/rules/specify-out-of-scope-original)
-    - adding the "[original version unknown](https://vocadb.net/T/4631)" tag
+  For derived songs, attribute the original by one of the following:
+    - Adding the original entry on the "Original version" field
+    - Adding the UtaiteDB/TouhouDB entry as an external link
+    - Following the "[Specify out-of-scope original](/rules/specify-out-of-scope-original)" rule
+    - Adding the "[original version unknown](https://vocadb.net/T/4631)" tag
 ---
 
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 
-Derived songs should have a reference to the original song by doing the following, in priority from top to bottom:
+The original song of a derivative should be attributed by doing one of the following, in priority from top to bottom:
 
-1. Specify the "Original version" field.
-2. Add the original entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/) as an external link. This will display it as the "Original version" along with automatic metadata.
-3. If it is out-of-scope of the database, follow [the "Specify out-of-scope original" rule](/rules/specify-out-of-scope-original).
-4. If it is unknown, add the [original version unknown](https://vocadb.net/T/4631) tag.
-
-This includes if the original song is out-of-scope. Refer to [the "Specify out-of-scope original" rule] for more information.
+1. Specify the entry in the "Original version" field.
+2. Add the entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/) as an external link. This will display it as the "Original version" along with automatic metadata.
+3. If it is out-of-scope of the database, follow the "[Specify out-of-scope original](/rules/specify-out-of-scope-original)" rule.
+4. If it is unknown, add the "[original version unknown](https://vocadb.net/T/4631)" tag.
 
 ## Related rules
 

--- a/src/content/rules/specify-original.mdx
+++ b/src/content/rules/specify-original.mdx
@@ -17,11 +17,25 @@ status: Active
 rule_context:
 mikumod_support: "Planned"
 relevant_tag_id: 4631
+excerpt: >
+  For derived songs, refer the original by...
+    - adding the song entry on the "Original version" field
+    - adding the UtaiteDB/TouhouDB entry as an external link
+    - following [the "Specify out-of-scope original" rule](/rules/specify-out-of-scope-original)
+    - adding the "[original version unknown](https://vocadb.net/T/4631)" tag
 ---
 
-Derived songs should either:
+import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
 
-- Specify the `Original version` field.
-- Refer as an external link to the original entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/), if applicable. This will display it as the "Original version" along with automatic metadata.
-- Include the [human original](https://vocadb.net/T/3193/human-original) or [instrumental original](https://vocadb.net/T/12491/instrumental-original) tag.
-- Include the [original version unknown](https://vocadb.net/T/4631) tag.
+Derived songs should have a reference to the original song by doing the following, in priority from top to bottom:
+
+1. Specify the "Original version" field.
+2. Add the original entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/) as an external link. This will display it as the "Original version" along with automatic metadata.
+3. If it is out-of-scope of the database, follow [the "Specify out-of-scope original" rule](/rules/specify-out-of-scope-original).
+4. If it is unknown, add the [original version unknown](https://vocadb.net/T/4631) tag.
+
+This includes if the original song is out-of-scope. Refer to [the "Specify out-of-scope original" rule] for more information.
+
+## Related rules
+
+<RuleEmbed ruleId={106} />

--- a/src/content/rules/specify-out-of-scope-original.mdx
+++ b/src/content/rules/specify-out-of-scope-original.mdx
@@ -17,9 +17,30 @@ status: Active
 rule_context:
 mikumod_support: "Planned"
 relevant_tag_id: 3282
+excerpt: >
+  For derived songs with out-of-scope original, add the respective tags ([human original](https://vocadb.net/T/3193)/[instrumental original](https://vocadb.net/T/12491)) and refer the original by...
+    - adding [the cover unifier](/rules/cover-unifiers) on the "Original version" field
+    - adding the UtaiteDB/TouhouDB entry as an external link
+    - mentioning it on the description
 ---
 
-If the [human original](https://vocadb.net/T/3193) tag or the [instrumental original](https://vocadb.net/T/12491/instrumental-original) tag is included, the original version should be:
+import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
+import { BoxGroup } from "@/components/Box.tsx";
 
-- specified in the song description AND/OR
-- included as an external link (required for UtaiteDB originals).
+If the original version of a vocal synth song is out of scope of the database, tag it with the following tags for songs with out-of-scope originals:
+
+- [human original](https://vocadb.net/T/3193)
+- [instrumental original](https://vocadb.net/T/12491)
+
+The original song should still be referred by doing the following, in priority from top to bottom:
+
+1. If [the cover unifier exists](/rules/cover-unifiers), specify it on the "Original version" field.
+2. Add the original entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/) as an external link.
+3. Mention it in the entry description. At least [the artist should be included](/rules/out-of-scope-artist-crediting-for-derived-songs). If the song title is different to the original, also include the original title.
+
+## Related rules
+
+<BoxGroup>
+  <RuleEmbed ruleId={155} />
+  <RuleEmbed ruleId={105} />
+</BoxGroup>

--- a/src/content/rules/specify-out-of-scope-original.mdx
+++ b/src/content/rules/specify-out-of-scope-original.mdx
@@ -18,10 +18,10 @@ rule_context:
 mikumod_support: "Planned"
 relevant_tag_id: 3282
 excerpt: >
-  For derived songs with out-of-scope original, add the respective tags ([human original](https://vocadb.net/T/3193)/[instrumental original](https://vocadb.net/T/12491)) and refer the original by...
-    - adding [the cover unifier](/rules/cover-unifiers) on the "Original version" field
-    - adding the UtaiteDB/TouhouDB entry as an external link
-    - mentioning it on the description
+  For derived songs with out-of-scope original, add the relevant tags ([human original](https://vocadb.net/T/3193)/[instrumental original](https://vocadb.net/T/12491)) and attribute the original by one of the following:
+    - Adding the [cover unifier](/rules/cover-unifiers) on the "Original version" field
+    - Adding the UtaiteDB/TouhouDB entry as an external link
+    - Mentioning it on the description
 ---
 
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";
@@ -32,10 +32,10 @@ If the original version of a vocal synth song is out of scope of the database, t
 - [human original](https://vocadb.net/T/3193)
 - [instrumental original](https://vocadb.net/T/12491)
 
-The original song should still be referred by doing the following, in priority from top to bottom:
+The original song should still be attributed by doing one of the following, in priority from top to bottom:
 
-1. If [the cover unifier exists](/rules/cover-unifiers), specify it on the "Original version" field.
-2. Add the original entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/) as an external link.
+1. If the [cover unifier](/rules/cover-unifiers) exists, specify it in the "Original version" field.
+2. Add the entry on [UtaiteDB](https://utaitedb.net/S/) or [TouhouDB](https://touhoudb.com/) as an external link.
 3. Mention it in the entry description. At least [the artist should be included](/rules/out-of-scope-artist-crediting-for-derived-songs). If the song title is different to the original, also include the original title.
 
 ## Related rules


### PR DESCRIPTION
This one quite doozy and took a while to consider.

I was going to mention "mentioning it on the description" on the "Specify original" rule, since the rule also covers out-of-scope originals, but then I realised that it exists on the "Specify out-of-scope original" rule, loosely connected with the out-of-scope original tag rule ("Include the [original out-of-scope] tag."). I also was going to think that doing that would make the rule overlap to one to each other (rule 1 applies for OoS, rule 2 applies on "included as an external link (required for UtaiteDB originals).", rule 3 applies on "specified in the song description").

Then, I got an idea to just strictly refer the rule "Specify out-of-scope original" on the "Specify original" rule and moving the OoS tagging rule to the OoS rule. This bypasses the loose connection of the out-of-scope original tagging rule and making the OoS rule reserved for handling OoS originals.

Also, having "[human original](https://vocadb.net/T/3193) tag or the [instrumental original](https://vocadb.net/T/12491/instrumental-original) tag" is too long for me to like it, so this PR also solves that by making it on a list.