### PR TITLE
Split quick links into two columns

### DIFF
--- a/src/content/docs/VocaDB wiki.mdx
+++ b/src/content/docs/VocaDB wiki.mdx
@@ -61,12 +61,13 @@ Also view the rules seperated by [albums](/rules/albums), [artists](/rules/artis
 
 ## Quick links
 
+<div class="lg:columns-2 [&_ul]:lg:my-0 [&_li]:lg:mt-0">
+
 - 👶 [Quick guide for new editors](/docs/quick-guide-for-new-editors)
 - 💪 [VocaDB - How to help](/docs/vocadb-how-to-help)
 - 🧾 [VocaDB editing FAQ](/docs/vocadb-editing-faq)
 - 🏴 [Entry reports](/docs/entry-reports)
 - 🈳 [Romanization guidelines](/docs/romanization-guidelines)
-
 - 🔍 [Search terms cheat sheet](/docs/search-terms-cheat-sheet)
 - 💬 [Discussion rules](/docs/discussion-rules)
 - 👥 [User groups](/docs/user-groups) (trusted users, moderators, ...)
@@ -74,6 +75,8 @@ Also view the rules seperated by [albums](/rules/albums), [artists](/rules/artis
 - 🕵🏻‍♂️ [Content policy](/docs/content-policy) (what kind of entries are accepted)
 - 🗑️ [Content removal guidelines](/docs/content-removal-guidelines) (how to remove entries)
 - ✅ [Artist verification](/docs/artist-verification) (how to claim artist entries)
+
+</div>
 
 ## Related pages
 


### PR DESCRIPTION
Since the cards are reverted, I decided to just splitting via `columns-2`. This would split the list into two (first half on left, second half on right) without having it as cards. If the viewpoint is narrow, it would still revert to a single column, similar to the card grids.

![](https://github.com/user-attachments/assets/5b2e3ca3-8268-4ad6-a198-f7c855029297)
