### PR TITLE
Adjust forbidden artists pages to be more clearer

### DIFF
--- a/src/content/docs/Forbidden artists AI.mdx
+++ b/src/content/docs/Forbidden artists AI.mdx
@@ -1,6 +1,6 @@
 ---
-title: Forbidden artists (AI music)
-description: This page contains a list of people that are banned from the database due to exclusively creating music with generative AI tools. For the main Forbidden artist list, please see [this page](https://wiki.vocadb.net/docs/artist-verification).
+title: Forbidden artists (AI-generated songs)
+description: This list includes artists that are banned from VocaDB for using only generative AI tools to create music. This is part of the [main forbidden artist page](/docs/forbidden-artists).
 parent: Artists
 tags:
   [
@@ -14,12 +14,14 @@ tags:
   ]
 ---
 
-This page contains a list of people that are banned from the database due to exclusively creating music with [generative AI tools](https://vocadb.net/T/10766/ai-generated-music) (e.g. [Suno AI](https://vocadb.net/T/10648/suno)).
-Songs exclusively made with these technologies are [not allowed on VocaDB](https://wiki.vocadb.net/rules/no-ai-generated-songs).
-If an artist on this list is in-scope otherwise, be that due to auxiliary non-musical elements (such as illustrations) or non-AI music, they should be removed from this list and instead given a page warning.
+This list includes artists who use **only** generative AI tools (such as [Suno AI](https://vocadb.net/T/10648)) to create music.
+[We do not allow songs made entirely with these technologies in VocaDB.](https://wiki.vocadb.net/rules/no-ai-generated-songs)
+
+This list is not for artists who also create other work, such as non-AI music or illustrations.
+If an artist is already listed for these reasons, remove them and add a warning to their entry description instead.
 
 For **existing** artist entries, please see the [content removal guidelines](/docs/content-removal-guidelines).
-For the main forbidden artist lists, please see [this page](https://wiki.vocadb.net/docs/forbidden-artists).
+For the main forbidden artist lists, please see [this page](/docs/forbidden-artists).
 
 - Niach (Niach-Nia)
   - [YouTube](https://www.youtube.com/channel/UCpdCH3vi_VoaozvynzU0MZw)

--- a/src/content/docs/Forbidden artists.mdx
+++ b/src/content/docs/Forbidden artists.mdx
@@ -1,6 +1,6 @@
 ---
-title: Forbidden artists (main)
-description: This page contains lists of artists whose entries are not allowed to be created on VocaDB. For existing artist entries, see the content removal guidelines. For the AI-focused forbidden artist list, please see [this page]
+title: Forbidden artists
+description: This page contains lists of artists whose entries are not allowed to be created on VocaDB. For existing artist entries, see the content removal guidelines.
 parent: Artists
 tags:
   [
@@ -15,15 +15,17 @@ tags:
 ---
 
 This page contains lists of artists whose entries are not allowed to be created on VocaDB.
-Please use custom artists if any of these people are attached to a song in an auxiliary, non-musical manner (i.e. as an illustrator).
-If they are attached to a song in a musical manner, please do not add that song.
-If a song they're attached to musically is already on the Database, it is to be removed, regardless of favourites or likes.
+
+[The entries to the artist and the songs produced by them should not be added.](/rules/no-forbidden-artist)
+If it is already made, it should be deleted regardless of [the deletion criteria](/content-removal-guidelines#criteria-for-valid-song-entry-deletion-requests).
+The artists can still be credited for non-producer roles by adding it as a custom artist.
 
 For **existing** artist entries, see the [content removal guidelines](/docs/content-removal-guidelines).
 
-## Artists who have requested their entries not to be added to the database
+## Requested for exclusion
 
-Artists may request to be either added to this list or removed from it.
+The following artists have requested their entries not to be added to the database.
+Artists may request to be either added to this list or removed from this list in accordance to [the guidelines](/docs/content-removal-guidelines).
 
 - 電波ゆん太郎 (白川蟻巣 / Shirakawa Arisu / Denpayun Tarou)
   - [~~Pixiv #1~~](https://www.pixiv.net/en/users/291448)
@@ -50,7 +52,9 @@ Artists may request to be either added to this list or removed from it.
   - [YouTube](https://www.youtube.com/channel/UCz-WcfZrpYHIiICikTYE3LA)
   - [SoundCloud](https://soundcloud.com/pplatonic)
 
-## Accounts/channels containing uploads that are confirmed stolen
+## Stolen content/theft
+
+The following artists have channels containing uploads that are confirmed stolen.
 
 - オーロラP (AuroraP, äURORA, どうか私を忘れてください)
   - [Niconico #1](https://www.nicovideo.jp/user/140264001)
@@ -72,7 +76,13 @@ Artists may request to be either added to this list or removed from it.
 - 0k [impersonated 0k27315c]
   - [SoundCloud](https://soundcloud.com/0k27315c)
 
-## Artists who have been banned from VocaDB due to on-site trolling
+## AI-generated songs
+
+_See "[Forbidden artists (AI-generated songs)](/docs/forbidden-artists-ai)"._
+
+## Bad faith edits
+
+The following artists have been banned from VocaDB for being involved in bad faith contributions (trolling).
 
 - taysz22 (taysssssszzzzzzz)
   - [YouTube](https://www.youtube.com/channel/UCa9HXolJt0rygEF-A-TY--g)

--- a/src/content/rules/no-ai-generated-songs.mdx
+++ b/src/content/rules/no-ai-generated-songs.mdx
@@ -31,4 +31,4 @@ Song entries for AI-generated songs (AI-generated music or AI-generated uncontro
 
 ## Related pages
 
-- [Forbidden artists](/docs/forbidden-artists)
+- [Forbidden artists (AI-generated songs)](/docs/forbidden-artists-ai)


### PR DESCRIPTION
The leading paragraphs for both pages for forbidden artists are quite heavy for me (as a non-native speaker) to understand. For example, I noticed some jargons that could be replaced with more known terms (e.g. "attached to a song in a musical manner" to "with producer roles"). As usual, I try to improve the language, but unlike before, getting the point across simply took me a while. I've experienced it before on GitHub, and that involved a US writer.

I also took time to adjust the headings into something shorter. I try to maintain the wording, especially when there are already abbreviations invented on the private channels (e.g. FATL for trolling). The only thing is that is quite significant is that I try to use "bad faith" instead of "trolling", though I'm still confused on what does "trolling" exactly mean ("bad faith editing" is quite general, but "disruptive editing" could be what it meant, see [Wikipedia:Acting in bad faith](https://en.wikipedia.org/wiki/Wikipedia:Acting_in_bad_faith), [Wikipedia:Disruptive editing](https://en.wikipedia.org/wiki/Wikipedia:Disruptive_editing), [Wikipedia:Gaming the system](https://en.wikipedia.org/wiki/Wikipedia:Gaming_the_system)).

I also do some edits for consistency between the list and the "No AI-generated songs" rule, along with some syntax improvements.