### PR TITLE
Do small improvements for content removal guidelines

### DIFF
--- a/src/content/docs/Content removal guidelines.mdx
+++ b/src/content/docs/Content removal guidelines.mdx
@@ -45,101 +45,96 @@ Content removal requests **must always be verified** in some way.
 - Having a [verified artist account on VocaDB](/docs/artist-verification) is one way of doing it.
 - A post directly from an artist's official channel/other account **directed at VocaDB/VocaDB staff/mods** also satisfies this criteria.
 
-Most of the time, the original source/media/video/link should be **deleted** or **privated** first to avoid someone adding it again on VocaDB.
+Most of the time, the original source (media/video/link) should be **deleted** or **privated** first to avoid someone adding it again on VocaDB.
 
 Deleted entries stay visible if accessed through the direct entry URL, but are hidden from the search and other website functions. Individual entry revisions can be hidden on deleted entries when requested.
 
-Users who follow or have liked an entry get a notification when the entry is deleted.
+Users who follow or have liked an entry will get a notification when the entry is deleted.
 
-If artist wants to create music without a VocaDB presence, they can request their name in the [forbidden artists page](/docs/forbidden-artists). This is one way of making sure that users do not add their entries to the site.
+If artist wants to create music without a VocaDB presence, they can request their name in [the forbidden artists page](/docs/forbidden-artists). This is one way of making sure that users do not add their entries to the site.
 
 For entries **that already exist**, check the following list(s) and leave an **entry report** or **communicate** to us in some way to have the content removed.
 
 - **Removing information using an unverified account without asking will result in edit permission removals and entry reverts!**.
 
-### Information that the artist can freely remove without asking:
+### Information that the artist can freely remove without asking
 
 Make sure to [verify your artist entry](/docs/artist-verification) first!
 
-1. Artist names:
+1. Artist names
+   - Uncommon aliases that are not in use. Name should not be visible on any official account or on any album cover.
+   - Real-life names (and other personal information) are always removed when requested, as long as there is some other name to use instead.
 
-- Uncommon aliases that are not in use. Name should not be visible on any official account or on any album cover.
-- Real-life names (and other personal information) are always removed when requested, as long as there is some other name to use instead.
+2. Images
+   - Artist & album pictures/images can be deleted (or replaced) in all cases.
 
-2. Images:
+3. External links
+   - In most cases, external links should be **marked as "unavailable"** instead of deleting them.
+   - Music-related links (Niconico, Youtube, etc.) should **stay**.
+   - Social media links (especially Twitter/X) **are useful** for searching and handling duplicates.
+   - Old blogs/websites **can be deleted** (prefer marking as unavailable).
+   - Links containing personal information can be deleted.
 
-- Artist & album pictures/images can be deleted (or replaced) in all cases.
+4. Reprint media
 
-3. External links:
-
-- In most cases, external links should be **marked as "unavailable"** instead of deleting them.
-- Music-related links (Niconico, Youtube, etc.) should **stay**.
-- Social media links (especially Twitter/X) **are useful** for searching and handling duplicates.
-- Old blogs/websites **can be deleted** (prefer marking as unavailable).
-- Links containing personal information can be deleted.
-
-4. Reprint links
-
-With the [do not reupload](https://vocadb.net/T/1695/do-not-reupload) tag on the artist/song entry.
+   With the [do not reupload](https://vocadb.net/T/1695/do-not-reupload) tag on the artist/song entry.
 
 5. Lyrics
 
-With the [no lyrics allowed](https://vocadb.net/T/12157) tag on the artist/song entry.
+   With the [no lyrics allowed](https://vocadb.net/T/12157) tag on the artist/song entry.
 
-## Criteria for valid artist entry deletion requests
+## Criteria for valid requests
+
+### Artist
 
 Artist entry deletions generally require that all album & song entries fulfill the relevant deletion criteria and are deleted first.
 
-- If only one song/album exists that doesn't fulfill the deletion criteria, the artist entry can be removed. In this case the artist credit is replaced with a custom artist.
+If only one song/album exists that doesn't fulfill the deletion criteria, the artist entry can be removed. In this case the artist credit is replaced with a custom artist.
 
-### Music producer
+#### Music producer
 
-Music producer artist entry can be deleted, if all (-1) of their song and album entries fulfill the deletion criteria (= all original media deleted, no song/album ratings).
+Music producer artist entry can be deleted, if all (but one) of their song and album entries fulfill the deletion criteria.
 
 Also applies to other artist types that are tagged with [music producer](https://vocadb.net/T/300/music-producer).
 
-### Cover artist
+#### Cover artist
 
 Cover song entries are always deleted when requested (assuming no official media available) which in most cases means that the cover artist entries are deleted when requested.
 
-### Animator
+#### Animator
 
 If the animator participates in song entries as a "producer" ("Music PV" or "Drama PV" song type), deletion criteria of "music producer" will be used. Otherwise (= collaborating with someone else), same criteria as **illustrator**.
 
-### Illustrator, Other vocalist, lyricist, instrumentalist, other invidual:
-
-Artist entry deleted and replaced with custom artist credits, if there are less than 5 entries where they participate.
-
-### Circle, Label, Other Group
+#### Circle, Label, Other group
 
 Can be deleted if all the relevant artist entries are deleted.
 
 Alternatively, solo circles can be merged with the producer artist entry.
 
-### Voicebanks
+#### Voicebanks
 
 Never deleted (with above exceptions), regardless of the voicebank engine.
 
 Voicebank connections (voice provider, voicebank illustrator, ...) are removed when requested from [discontinued voicebanks](https://vocadb.net/T/2882).
 
-## Criteria for valid song entry deletion requests
+#### Other roles (illustrator, other vocalist, lyricist, instrumentalist, other invidual)
+
+Artist entry deleted and replaced with custom artist credits, if there are less than 5 entries where they participate.
+
+### Song
 
 To delete individual song entries, two conditions apply:
 
-1. No public official media available.
-
+1. No public official (original) media available.
 2. No song ratings.
-
-- Cover song entries can be removed regardless of the song ratings.
+   - Cover song entries can be removed regardless of the song ratings.
 
 For songs entries, you can alternatively request the [do not reupload](https://vocadb.net/T/1695/do-not-reupload) tag be added your artist/song entries, which removes existing and future reprint links.
 
-## Criteria for valid album entry deletion requests
+### Album
 
 To delete individual album entries, three conditions apply:
 
-1. All album tracks (song entries) fulfill the above song deletion checklist.
-
+1. All album tracks (song entries) fulfill the above song deletion criteria.
 2. No official information available (crossfades/store links).
-
 3. Not in any user collection.


### PR DESCRIPTION
Plenty of small fixes and improvements for the "Content removal guidelines" page.

- Add parent criteria heading, shorten subheadings
- Fix syntax to make tidier lists
- Small (linguistic) changes