### PR TITLE
Update instrumental-classification.mdx

### DIFF
--- a/src/content/rules/instrumental-classification.mdx
+++ b/src/content/rules/instrumental-classification.mdx
@@ -17,7 +17,7 @@ status: Active
 rule_context:
 mikumod_support: "False"
 relevant_tag_id: 208
-excerpt: The "Instrumental" song type is used for instrumental versions of a song available in an album.
+excerpt: The "Instrumental" song type is used for instrumental versions of a song available in an album (a.k.a. off-vocal/karaoke).
 ---
 
 import RuleEmbed from "@/components/markdown/RuleEmbed.astro";


### PR DESCRIPTION
added "(a.k.a. off-vocal/karaoke)" to the end of the rule itself.