### PR TITLE
Remove OKISO from "Forbidden artist (AI-generated songs)"

### DIFF
--- a/src/content/docs/Forbidden artists AI.mdx
+++ b/src/content/docs/Forbidden artists AI.mdx
@@ -138,9 +138,6 @@ For the main forbidden artist lists, please see [this page](/docs/forbidden-arti
 - ivmare
   - [YouTube](https://www.youtube.com/channel/UC-lYcyrR0LHTIaF5sEZG4dQ)
   - [Spotify](https://open.spotify.com/artist/4bG3wW1JRQnRXEnosPp6VV)
-- OKISO
-  - [YouTube](https://www.youtube.com/channel/UCNO2N-pl14P4MdrRZp2UCuA)
-  - [Website](https://okiso.net/)
 - ROKΛI
   - [Niconico](https://www.nicovideo.jp/user/140154826)
   - [YouTube](https://www.youtube.com/channel/UCyZfjOmlEirCi9Ff45_scWA)


### PR DESCRIPTION
The intro of the page said that it is for artist who only do AI-generated songs.

> This list is not for artists who also create other work, such as non-AI music or illustrations. If an artist is already listed for these reasons, remove them and add a warning to their entry description instead.

*Before my changes (#131)*:

> If an artist on this list is in-scope otherwise, be that due to auxiliary non-musical elements (such as illustrations) or non-AI music, they should be removed from this list and instead given a page warning.

OKISO has an artist entry on https://vocadb.net/Ar/157381, and there are songs on VocaDB to this date, which I assume is legal to stay on VocaDB. In addition to that, a warning has been added on the entry description.

> Producer uploads uncredited Suno AI generations as original songs. Please take caution when adding songs.

This means that the artist shouldn't be on this list. This PR removes this previous addition.

Note that this does not mean that AI-generated songs made by this artist is automatically eligible, as it is covered by the existing AI-generated songs rule. This is to reflect the current state of entries. In case anyone disagrees, please ensure that the song entries are eligible (or not). If it is legal, this PR stands. If it is not, please delete the entries (in accordance to the mentioned rule) so that this PR is not needed anymore.