### PR TITLE
Fix links to rules on Forbidden artists

### DIFF
--- a/src/content/docs/Forbidden artists.mdx
+++ b/src/content/docs/Forbidden artists.mdx
@@ -16,7 +16,7 @@ tags:
 
 This page contains lists of artists whose entries are not allowed to be created on VocaDB.
 
-[The entries to the artist and the songs produced by them should not be added.](/rules/no-forbidden-artist)
+The entries to [the artist](/rules/no-forbidden-artists) and [the songs produced by them](/rules/no-song-entries-by-forbidden-artists) should not be added.
 If it is already made, it should be deleted regardless of [the deletion criteria](/content-removal-guidelines#criteria-for-valid-song-entry-deletion-requests).
 The artists can still be credited for non-producer roles by adding it as a custom artist.
 


### PR DESCRIPTION
Minor change to fix the broken link, as well as linking directly to the rule that forbids creating the song entries.